### PR TITLE
Update Observer puzzle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # puzzlepull
 
-This code scrapes and converts crossword puzzles online in HTML format to a [`.ipuz`](http://www.ipuz.org/) format.
+This code converts crossword puzzles from around the web from HTML to the [`.ipuz`](http://www.ipuz.org/) format.
 This allows the puzzles to be uploaded and solved on sites like [squares.io](http://squares.io/).
 
 You can use the service by visiting [the associated webpage](https://puzzlepull.space.jarred.green).
+
+### Compatible Sites:
+
+Please open an issue if you would like to see a site added.
+
+- [The Guardian](https://www.theguardian.com/)
+- [The Observer](https://www.observer.co.uk/)
+  - Only the Everyman and Speedy puzzles are currently supported.

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,8 +5,6 @@ services:
     container_name: backend
     expose:
       - "8022"
-    ports:
-      - "8022:8022"
     command: fastapi run main.py --port 8022
 
   frontend:
@@ -16,8 +14,8 @@ services:
         - REDIS_URL=${REDIS_URL}
         - API_URL=${API_URL}
     container_name: frontend
-    ports:
-      - "4000:4000"
+    expose:
+      - "4000"
     environment:
       - REDIS_URL=${REDIS_URL}
       - API_URL=${API_URL}


### PR DESCRIPTION
The Observer site changed its HTML structure. The scraper was looking for a `div` with class `pm-embed-div` that no longer exists, causing an `AttributeError`.

**Changes:**
- Extract puzzle `id` and `set` from the iframe `src` attribute (new structure)
- Fallback to the old `pm-embed-div` method if needed
- Update URL format from `puzzleme` to `pmm` domain path
- Add error handling if puzzle data isn't found