### PR TITLE
observer: fix spaces next to tags being stripped

### DIFF
--- a/api/puzzlepull/observer.py
+++ b/api/puzzlepull/observer.py
@@ -140,7 +140,7 @@ def parse_crossword_clues(soup: BeautifulSoup, is_across: bool) -> list:
             clue_number_element.get_text(strip=True) if clue_number_element else None
         )
         clue_text = (
-            clue_text_element.get_text().strip() if clue_text_element else None
+            clue_text_element.get_text(" ", strip=True) if clue_text_element else None
         )
         word_lens_raw = (
             word_lens_element.get_text(strip=True) if word_lens_element else None

--- a/api/puzzlepull/observer.py
+++ b/api/puzzlepull/observer.py
@@ -140,7 +140,7 @@ def parse_crossword_clues(soup: BeautifulSoup, is_across: bool) -> list:
             clue_number_element.get_text(strip=True) if clue_number_element else None
         )
         clue_text = (
-            clue_text_element.get_text(strip=True) if clue_text_element else None
+            clue_text_element.get_text().strip() if clue_text_element else None
         )
         word_lens_raw = (
             word_lens_element.get_text(strip=True) if word_lens_element else None


### PR DESCRIPTION
example of issue in everyman 4,133

input: `Roll up! <i>Not one</i> old nag`
output: `Roll up!Not oneold nag`