### PR TITLE
observer: don't use underscores in title field

### DIFF
--- a/api/puzzlepull/observer.py
+++ b/api/puzzlepull/observer.py
@@ -303,7 +303,7 @@ def get_observer_puzzle(
     puzzle["author"] = "Everyman Crossword"
     puzzle["publisher"] = "The Observer"
     puzzle["url"] = url
-    puzzle["title"] = title
+    puzzle["title"] = title.replace("_", " ")
     puzzle["date"] = dt.strftime("%m/%d/%Y")
     puzzle["dimensions"] = dict(width=len(grid[0]), height=len(grid))
     puzzle["puzzle"] = grid


### PR DESCRIPTION
use spaces in the displayed title

was:  `Everyman_4,134_(11_January)`
now: `Everyman 4,134 (11 January)`